### PR TITLE
Made navigation responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
     <link rel="stylesheet" type="text/css" href="stylesheet.css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
@@ -11,20 +12,25 @@
     <link rel="apple-touch-icon" sizes="180x180" href="Images/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="Images/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="Images/favicon-16x16.png">
+    <script src="main.js"></script>
 </head>
 
 <body>
-    <div class="nav">
-       <ul>
-            <li><a href="#">Start Here</a></li>
-            <li><a href="#">General Resources</a></li>
-            <li><a href="#">Low-Income Families</a></li> 
-            <li><a href="#">College Students</a></li>
-            <li><a href="#">Senior Citizens</a></li>
-            <li><a href="#">Printables</a></li>
-            <li><a href="#">Contact Us</a></li>
-       </ul>
-    </div>
+    <nav class="navbar">
+        <span class="navbar-toggle" id="js-navbar-toggle">
+            <i class="fa fa-bars"></i>
+        </span>
+        <ul class="main-nav" id="js-menu">
+            <li><a href="#" class="nav-links">Start Here</a></li>
+            <li><a href="#" class="nav-links">General Resources</a></li>
+            <li><a href="#" class="nav-links">Families</a></li>
+            <li><a href="#" class="nav-links">College</a></li>
+            <li><a href="#" class="nav-links">Seniors</a></li>
+            <li><a href="#" class="nav-links">Printables</a></li>
+            <li><a href="#" class="nav-links">Contact</a></li>
+        </ul>
+    </nav>
+
     <div class="heading">
         <h1>Pathways to Housing</h1>
         <h2><em>An affordable housing resource for helping professionals</em></h2>

--- a/index.html
+++ b/index.html
@@ -16,13 +16,13 @@
 <body>
     <div class="nav">
        <ul>
-            <li>Start Here</li>
-            <li>General Resources</li>
-            <li>Low-Income Families</li> 
-            <li>College Students</li>
-            <li>Senior Citizens</li>
-            <li>Printables</li>
-            <li>Contact Us</li>
+            <li><a href="#">Start Here</a></li>
+            <li><a href="#">General Resources</a></li>
+            <li><a href="#">Low-Income Families</a></li> 
+            <li><a href="#">College Students</a></li>
+            <li><a href="#">Senior Citizens</a></li>
+            <li><a href="#">Printables</a></li>
+            <li><a href="#">Contact Us</a></li>
        </ul>
     </div>
     <div class="heading">

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 
 <footer>
     <div class="footer">
-        <a href="hello@pathwaystohousing.com">Contact us: hello@pathwaystohousing.com</a>
+        <a href="mailto:hello@pathwaystohousing.com">Contact us: hello@pathwaystohousing.com</a>
     </div>
 </footer>
 

--- a/main.js
+++ b/main.js
@@ -1,0 +1,6 @@
+let mainNav = document.getElementById('js-menu');
+let navBarToggle = document.getElementById('js-navbar-toggle');
+
+navBarToggle.addEventListener('click', function () {
+  mainNav.classList.toggle('active');
+});

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -32,7 +32,15 @@ html::after {
     display: flex;
     flex-direction: row;
     justify-content: space-evenly;  
-    align-items: center; 
+    align-items: center;
+}
+
+.nav li {
+    padding: 14px;
+}
+
+.nav li:hover {
+    background-color: #F5BB00;
 }
 
 .heading {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -24,7 +24,7 @@ html::after {
   * {
     margin: 0;
   }
-  
+
 .nav {
     background-color: #1C3F21;
     color: #fffdf2;
@@ -37,13 +37,15 @@ html::after {
     flex-direction: row;
     justify-content: space-evenly;  
     align-items: center;
+    margin: 0;
+    padding: 0;
 }
 
 .nav li {
     padding: 14px;
 }
 
-.nav li:hover {
+.nav a:hover {
     background-color: #F5BB00;
 }
 
@@ -99,7 +101,7 @@ a {
     text-decoration: none;
 }
 
-a:hover {
+div.footer a:hover {
     color:#F5BB00;
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -22,31 +22,76 @@ html::after {
   }
 
   * {
+    box-sizing: border-box;
+    padding: 0;
     margin: 0;
   }
 
-.nav {
+.navbar {
+    font-size: 1em;
     background-color: #1C3F21;
-    color: #fffdf2;
-    height: 50px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    padding: 25px;
+}
+.main-nav {
+    list-style-type: none;
+    display: none;
 }
 
-.nav ul {
-    list-style: none;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;  
-    align-items: center;
-    margin: 0;
-    padding: 0;
+.nav-links {
+    text-decoration: none;
+    color: rgba(255, 255, 255, 0.7);
 }
 
-.nav li {
-    padding: 14px;
+.main-nav li {
+    text-align: center;
+    margin: 15px auto;
 }
 
-.nav a:hover {
-    background-color: #F5BB00;
+.navbar-toggle {
+    position: absolute;
+    top: 10px;
+    right: 20px;
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 24px;
+}
+
+.active {
+    display: block;
+}
+
+@media screen and (min-width: 768px) {
+    .navbar {
+        display: flex;
+        justify-content: space-between;
+        padding-bottom: 10;
+        height: 70px;
+        align-items: center;
+    }
+
+    .main-nav {
+        display: flex;
+        margin-right: 30px;
+        flex-direction: row;
+        justify-content: flex-end;
+    }
+
+    .main-nav li {
+        margin: 0;
+    }
+
+    .nav-links {
+        margin-left: 40px;
+    }
+
+    .navbar-toggle {
+        display: none;
+    }
+
+    .nav-links:hover {
+        color: rgba(255, 255, 255, 1);
+    }
 }
 
 .heading {
@@ -96,13 +141,13 @@ footer {
 
 div.footer,
 a {
-    color: #fffdf2; 
+    color: rgba(255, 255, 255, 0.7);
     padding: 15px 20px;
     text-decoration: none;
 }
 
 div.footer a:hover {
-    color:#F5BB00;
+    color: rgba(255, 255, 255, 1);
 }
 
 a:active {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -21,6 +21,10 @@ html::after {
     z-index: -1;   
   }
 
+  * {
+    margin: 0;
+  }
+  
 .nav {
     background-color: #1C3F21;
     color: #fffdf2;


### PR DESCRIPTION
I coded a mobile-first navigation bar with a media query for desktop viewing. I had to shorten the navigation items, as items with two words (ie: Senior Citizens, College Students) were stacking funny when viewing with smaller screens. You will be able to see the weirdness with 'Start Here' when you make it smaller.

When you squish it to tablet and mobile size the nav items should disappear and a hamburger menu should appear. It should display a drop-down menu when clicking on it, but I haven't gotten the js to play nice yet.

I also used a brighter white text for hover state, as we wanted to keep the coloring scheme simple. I can change this to a background-color highlight if folks would rather go that way.